### PR TITLE
Fix OpenSDK validation warnings

### DIFF
--- a/src/config/default/manager_auth_proxy_patch.yaml
+++ b/src/config/default/manager_auth_proxy_patch.yaml
@@ -22,6 +22,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/src/config/manifests/bases/ibm-security-verify-access-operator.clusterserviceversion.yaml
+++ b/src/config/manifests/bases/ibm-security-verify-access-operator.clusterserviceversion.yaml
@@ -13,9 +13,6 @@ metadata:
     description: The IBM Security Verify Access Operator manages the lifecycle of IBM Security Verify Access worker containers.
     repository: https://github.com/IBM-Security/verify-access-operator
     support: IBM
-    # Prevent cluster upgrades to OpenShift Version 4.9 when this 
-    # bundle is installed on the cluster
-    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
   name: ibm-security-verify-access-operator.v0000.0000.0000
   namespace: placeholder
 spec:


### PR DESCRIPTION
Signed-off-by: asha <ashashiv@au1.ibm.com>
Resolving warnings from opensdk validation for the operator:

WARN[0000] Warning: Value : found olm.properties annotation, please define these properties in metadata/properties.yaml instead 
WARN[0000] Warning: Value ibm-security-verify-access-operator.v22.10.0: unable to find the resource requests for the container: (kube-rbac-proxy). It is recommended to ensure the resource request for CPU and Memory. Be aware that for some clusters configurations it is required to specify requests or limits for those values. Otherwise, the system or quota may reject Pod creation. More info: https://master.sdk.operatorframework.io/docs/best-practices/managing-resources/ 
INFO[0000] All validation tests have completed successfully 


Results After these changes:

operator-sdk bundle validate ./22.10.0/ --select-optional suite=operatorframework
INFO[0000] All validation tests have completed successfully 

