### PR TITLE
Add registry hostname to image to allow operator tests to pull

### DIFF
--- a/src/config/manifests/bases/ibm-security-verify-access-operator.clusterserviceversion.yaml
+++ b/src/config/manifests/bases/ibm-security-verify-access-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Security
     certified: "false"
-    containerImage: ibmcom/verify-access-operator:0000.0000.0000
+    containerImage: docker.io/ibmcom/verify-access-operator:0000.0000.0000
     createdAt: --date--
     description: The IBM Security Verify Access Operator manages the lifecycle of IBM Security Verify Access worker containers.
     repository: https://github.com/IBM-Security/verify-access-operator


### PR DESCRIPTION
Signed-off-by: asha <ashashiv@au1.ibm.com>

Fixing:
Looks like the test is failing when it fails to fetch the image..
TASK [check_image_availability : Pull external operator image 'ibmcom/verify-access-operator:22.10.0' on Kubernetes] ***
fatal: [localhost]: FAILED! => changed=true 
  cmd: podman pull ibmcom/verify-access-operator:22.10.0
  delta: '0:00:00.046626'
  end: '2022-10-06 01:10:19.999828'
  msg: non-zero return code
  rc: 125
  start: '2022-10-06 01:10:19.953202'
  stderr: 'Error: short-name resolution enforced but cannot prompt without a TTY'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
...ignoring

TASK [check_image_availability : Print err message on Kubernetes] **************
fatal: [localhost]: FAILED! => changed=false 
  msg: Unable to pull ibmcom/verify-access-operator:22.10.0, please check permissions or path.



Checking locally: 
podman pull ibmcom/verify-access-operator:22.10.0
Resolving "ibmcom/verify-access-operator" using unqualified-search registries (/etc/containers/registries.conf.d/999-podman-machine.conf)
Trying to pull docker.io/ibmcom/verify-access-operator:22.10.0...