### PR TITLE
Fix for volume and volumemounts

### DIFF
--- a/src/internal/controller/ibmsecurityverifyaccess_controller.go
+++ b/src/internal/controller/ibmsecurityverifyaccess_controller.go
@@ -594,10 +594,10 @@ func (r *IBMSecurityVerifyAccessReconciler) deploymentForVerifyAccess(
 	}
 
 	maxVolMnts := len(m.Spec.Container.VolumeMounts)
-	volMnts := make([]corev1.VolumeMount, 0, maxVolMnts+1)
+	volMnts := make([]corev1.VolumeMount, maxVolMnts, maxVolMnts+1)
 	copy(volMnts, m.Spec.Container.VolumeMounts)
 	maxVols := len(m.Spec.Volumes)
-	vols := make([]corev1.Volume, 0, maxVols+1)
+	vols := make([]corev1.Volume, maxVols, maxVols+1)
 	copy(vols, m.Spec.Volumes)
 	if addSnapMgrCert == true {
 		r.Log.V(5).Info("Adding snapshot manager service TLS certificate to deployment.")


### PR DESCRIPTION
Volumes defined in `spec.volumes` and volume mounts defined in `spec.container.volumeMounts` section is not being copied to the deployment.